### PR TITLE
Fix non-check of bytes sent over Unix socket

### DIFF
--- a/flexget/plugins/clients/rtorrent.py
+++ b/flexget/plugins/clients/rtorrent.py
@@ -129,7 +129,7 @@ class SCGITransport(xmlrpc_client.Transport):
 
             self.verbose = verbose
 
-            sock.send(request_body.encode())
+            sock.sendall(request_body.encode())
 
             return self.parse_response(sock.makefile())
         finally:


### PR DESCRIPTION
I noticed a very strange issue with rTorrent; payloads/torrent encoded payloads bigger than 16256 bytes were failing.  I put some logging around this `sock.send` line.  Here's a working example:

```2017-05-11 20:27 VERBOSE  rtorrent      task   Calling load.raw()
2017-05-11 20:27 INFO     rtorrent      task   Sending body of len: 11344
2017-05-11 20:27 INFO     rtorrent      task   Actually sent len: 11344
2017-05-11 20:27 INFO     rtorrent      task   Sending body of len: 1026
2017-05-11 20:27 INFO     rtorrent      task   Actually sent len: 1026
2017-05-11 20:27 INFO     rtorrent      task   some.torrent.title added to rtorrent
```

And this is a broken example:

```2017-05-11 13:20 INFO     rtorrent      task Sending body of len: 5734
2017-05-11 13:20 INFO     rtorrent      task Actually sent len: 5734
2017-05-11 13:20 INFO     rtorrent      task Sending body of len: 18164
2017-05-11 13:20 INFO     rtorrent      task Actually sent len: 16256
2017-05-11 13:20 ERROR    rtorrent      task timed out
```

... and is then followed by an exception.

Using `socket.sendall` may not be the ideal solution, but it seems good enough for me.
